### PR TITLE
Foundation of OAuth2 Server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/app.js
+++ b/app.js
@@ -28,27 +28,6 @@ app.oauth = new oauthServer({
   model: require('./model')
 });
 
-app.use('/', index);
-app.use('/users', users);
-
-// catch 404 and forward to error handler
-app.use(function(req, res, next) {
-  var err = new Error('Not Found');
-  err.status = 404;
-  next(err);
-});
-
-// error handler
-app.use(function(err, req, res, next) {
-  // set locals, only providing error in development
-  res.locals.message = err.message;
-  res.locals.error = req.app.get('env') === 'development' ? err : {};
-
-  // render the error page
-  res.status(err.status || 500);
-  res.render('error');
-});
-
 // Post token.
 app.post('/oauth/token', app.oauth.token());
 

--- a/app.js
+++ b/app.js
@@ -42,4 +42,8 @@ app.get('/public', function(req, res) {
   res.send('Public area');
 });
 
+app.get('/', function(req, res, next) {
+  res.render('index', { title: 'Express' });
+});
+
 module.exports = app;

--- a/app.js
+++ b/app.js
@@ -4,6 +4,7 @@ var favicon = require('serve-favicon');
 var logger = require('morgan');
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
+var oauthServer = require('express-oauth-server');
 
 var index = require('./routes/index');
 var users = require('./routes/users');
@@ -21,6 +22,11 @@ app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: false }));
 app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
+
+// Add OAuth server.
+app.oauth = new oauthServer({
+  model: require('./model')
+});
 
 app.use('/', index);
 app.use('/users', users);
@@ -41,6 +47,20 @@ app.use(function(err, req, res, next) {
   // render the error page
   res.status(err.status || 500);
   res.render('error');
+});
+
+// Post token.
+app.post('/oauth/token', app.oauth.token());
+
+// Get secret.
+app.get('/secret', app.oauth.authenticate(), function(req, res) {
+  // Will require a valid access_token.
+  res.send('Secret area');
+});
+
+app.get('/public', function(req, res) {
+  // Does not require an access_token.
+  res.send('Public area');
 });
 
 module.exports = app;

--- a/model.js
+++ b/model.js
@@ -1,0 +1,103 @@
+
+/**
+ * Module dependencies.
+ */
+const pgp = require('pg-promise')();
+const uuidv4 = require('uuid/v4');
+
+// 'postgres://postgres:@localhost/postgres'
+const pg = pgp(process.env.DATABASE_URL); // database instance;
+
+/*
+ * Get access token.
+ */
+
+module.exports.getAccessToken = function(bearerToken) {
+  return pg.query('SELECT access_token, access_token_expires_on, client_id, refresh_token, refresh_token_expires_on, user_id FROM oauth_tokens WHERE access_token = $1', [bearerToken])
+    .then(function(result) {
+      if(!result || result.length == 0){
+        return null;
+      }
+      var token = result[0];
+      return {
+        accessToken: token.access_token,
+        client: {id: token.client_id},
+        accessTokenExpiresAt: token.access_token_expires_on,
+        user: {id: token.user_id}, // could be any object
+      };
+    });
+};
+
+/**
+ * Get client.
+ */
+
+module.exports.getClient = function *(clientId, clientSecret) {
+  return pg.query('SELECT client_id, client_secret, redirect_uri FROM oauth_clients WHERE client_id = $1 AND client_secret = $2', [clientId, clientSecret])
+    .then(function(result) {
+      if(!result || result.length == 0){
+        return;
+      }
+      var oAuthClient = result[0];
+
+      if (!oAuthClient) {
+        return;
+      }
+
+      return {
+        clientId: oAuthClient.client_id,
+        clientSecret: oAuthClient.client_secret,
+        grants: ['password'], // the list of OAuth2 grant types that should be allowed
+      };
+    });
+};
+
+/**
+ * Get refresh token.
+ */
+
+module.exports.getRefreshToken = function *(bearerToken) {
+  return pg.query('SELECT access_token, access_token_expires_on, client_id, refresh_token, refresh_token_expires_on, user_id FROM oauth_tokens WHERE refresh_token = $1', [bearerToken])
+    .then(function(result) {
+      return result.rowCount ? result.rows[0] : false;
+    });
+};
+
+/*
+ * Get user.
+ */
+
+module.exports.getUser = function *(username, password) {
+  return pg.query('SELECT id FROM users WHERE username = $1 AND password = $2', [username, password])
+    .then(function(result) {
+        if(!result || result.length == 0){
+          return;
+        }
+
+        return result[0];
+    });
+};
+
+/**
+ * Save token.
+ */
+
+module.exports.saveToken = function *(token, client, user) {
+  return pg.query('INSERT INTO oauth_tokens(access_token, access_token_expires_on, client_id, refresh_token, refresh_token_expires_on, user_id, id) VALUES ($1, $2, $3, $4, $5, $6, $7) RETURNING id, access_token, client_id, access_token_expires_on, user_id', [
+    token.accessToken,
+    token.accessTokenExpiresAt,
+    client.clientId,
+    token.refreshToken,
+    token.refreshTokenExpiresAt,
+    user.id,
+    uuidv4()
+  ]).then(function(result) {
+    console.log(result);
+    return {
+      accessToken: result[0].access_token,
+      client: {id: result[0].client_id},
+      accessTokenExpiresAt: result[0].access_token_expires_on,
+      user: {id: result[0].user_id}, // could be any object
+    };
+  });
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "ejs": "~2.5.6",
     "express": "~4.15.2",
     "morgan": "~1.8.1",
-    "serve-favicon": "~2.4.2"
+    "serve-favicon": "~2.4.2",
+    "express-oauth-server": "^2.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,10 @@
     "debug": "~2.6.3",
     "ejs": "~2.5.6",
     "express": "~4.15.2",
+    "express-oauth-server": "^2.0.0",
     "morgan": "~1.8.1",
+    "pg-promise": "^6.5.1",
     "serve-favicon": "~2.4.2",
-    "express-oauth-server": "^2.0.0"
+    "uuid": "^3.1.0"
   }
 }


### PR DESCRIPTION
This pull request contains
- Boilerplate structure of Express.js
- Implementation of "express-oauth-server" using PostgreSQL

The API for OAuth2 has been manually tested. The available APIs are:
### Authentication with Username and Password
Clients will need to send the client_id, client_secret, username, password and gran_type to the endpoint "/oauth/token" to obtain new access token.
`
curl -X POST -d "client_id=mobile_android&client_secret=secret&grant_type=password&username=nimbl3test&password=helloworld" http://localhost:3000/oauth/token
`

### Authorization with Access Token
To connect with the protected APIs, clients will need to send request with Bearer token header according to the OAuth2.0 standard. The header of the request should look like this.
`Authorization: Bearer <ACCESS-TOKEN>`
This API can be tested using:
`curl --header "Authorization: Bearer 76a3152758bbc5cf3a9f28cd3237d5ecf662b59c" http://localhost:3000/secret`

TODO
- Change the styling to ES6
- Error handling in model.js
- More testing